### PR TITLE
Handle welcome card login and harden SMTP config

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Run scraper
         env:
+          # Provide Allocate + SMTP credentials to the script
           ALLOCATE_USER: ${{ secrets.ALLOCATE_USER }}
           ALLOCATE_PASS: ${{ secrets.ALLOCATE_PASS }}
           SMTP_HOST:     ${{ secrets.SMTP_HOST }}


### PR DESCRIPTION
## Summary
- handle the welcome card flow before filling the Loop login form and add lightweight progress logs
- fall back to port 465 when the SMTP port secret is empty so email alerts keep working
- document the secrets passed into the scraper workflow step for Allocate credentials and SMTP configuration

## Testing
- python -m compileall scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68de99957c8483309703ac6273da6a46