### PR TITLE
Improve Auth0 Lock login resilience and capture diagnostics

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -47,6 +47,14 @@ jobs:
           SMTP_TO:       ${{ secrets.SMTP_TO }}
         run: python scraper.py
 
+      - name: Upload screenshots (if any)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scraper-screens
+          path: |
+            *.png
+
       - name: Persist state files back to repo (seen_ids & storage_state)
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- add resilient Auth0 Lock form handling with fallback selectors, detailed logging, and failure capture
- upload any login screenshots captured during CI runs for easier diagnostics

## Testing
- python -m compileall scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68de9f33f6f08330a605a392d4d19ea5