### PR TITLE
Shorten jitter and tighten workflow schedule

### DIFF
--- a/.github/workflows/scraper.yml
+++ b/.github/workflows/scraper.yml
@@ -2,21 +2,25 @@ name: shift-scraper
 
 on:
   schedule:
-    - cron: "*/15 * * * *"   # every 15 minutes
+    - cron: "*/10 7-21 * * *"   # every 10 minutes, 07:00–21:59 UTC
   workflow_dispatch:
+
+concurrency:
+  group: shift-scraper
+  cancel-in-progress: true
 
 jobs:
   run:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 12
 
     steps:
-      - name: Jitter 30–120s to avoid perfect regularity
+      - name: Jitter 4–37s to avoid perfect regularity
         run: |
           python - <<'PY'
           import random, time
-          t = random.uniform(30, 120)
-          print(f"Sleeping {t:.1f}s for jitter")
+          t = random.uniform(4, 37)
+          print(f"jitter: sleeping {t:.1f}s before scrape")
           time.sleep(t)
           PY
 
@@ -27,6 +31,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache Playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-ms-playwright-1
 
       - name: Install dependencies
         run: |

--- a/scraper.py
+++ b/scraper.py
@@ -21,8 +21,10 @@ USER_AGENTS = [
 ]
 
 def jitter_sleep():
-    # 30–120s jitter so we don't look like a metronome
-    delay = random.uniform(30, 120)
+    # Shorter, still human-like jitter: 4–37 seconds
+    import random, time
+    delay = random.uniform(4, 37)
+    print(f"jitter: sleeping {delay:.1f}s before scrape")
     time.sleep(delay)
 
 


### PR DESCRIPTION
## Summary
- shorten the scraper jitter sleep and log the chosen delay
- run the workflow every 10 minutes during daytime hours with concurrency control
- cache pip and Playwright downloads to speed up repeated runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea1455a2c833083339ad47ec9e95e